### PR TITLE
Account Self Testing flows

### DIFF
--- a/test/backgrounds/flows/account-self-testing-screening-analysis.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-analysis.feature
@@ -1,0 +1,2 @@
+  On the AccountSelfTestingScreeningAnalysis webpage
+    Then the URI should start with AccountSelfTestingScreeningAnalysis

--- a/test/backgrounds/flows/account-self-testing-screening-attestation-agree.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-attestation-agree.feature
@@ -1,0 +1,4 @@
+Self Testing Step 3aa.
+  On the AccountSelfTestingScreeningAttestation webpage
+  And I click the button //*[@id="agree-attestation"]
+  #Then the URI should start with AccountSelfTestingScreeningReview

--- a/test/backgrounds/flows/account-self-testing-screening-attestation-disagree.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-attestation-disagree.feature
@@ -1,0 +1,4 @@
+Self Testing Step 3ab.
+  On the AccountSelfTestingScreeningAttestation webpage
+  And I click the button //*[@id="decline-attestation"]
+  #Then the URI should start with AccountSelfTestingScreeningReview

--- a/test/backgrounds/flows/account-self-testing-screening-kit-confirmatory.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-kit-confirmatory.feature
@@ -1,0 +1,5 @@
+Self Testing Step 2.
+  On the AccountSelfTestingScreeningKit webpage
+  When I select Confirmatory Test for //*[@id="kitdropdown"]
+  And I click the button //*[@id="btn-nextMask"]
+  Then the URI should start with AccountSelfTestingScreeningResults

--- a/test/backgrounds/flows/account-self-testing-screening-kit-quidel.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-kit-quidel.feature
@@ -1,0 +1,5 @@
+Self Testing Step 2.
+  On the AccountSelfTestingScreeningKit webpage
+  When I select Quidel QuickVue for //*[@id="kitdropdown"]
+  And I click the button //*[@id="btn-nextMask"]
+  Then the URI should start with AccountSelfTestingScreeningAttestation

--- a/test/backgrounds/flows/account-self-testing-screening-results-inconclusive.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-results-inconclusive.feature
@@ -1,0 +1,6 @@
+Self Testing Step 3b.
+  On the AccountSelfTestingScreeningResults webpage
+  When I select Inconclusive for //*[@id="resultdropdown"]
+  And I click the button //*[@id="btn-nextMask"]
+  pause for 1s
+  #Then the URI should start with AccountSelfTestingScreeningReview

--- a/test/backgrounds/flows/account-self-testing-screening-results-negative.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-results-negative.feature
@@ -1,0 +1,6 @@
+Self Testing Step 3b.
+  On the AccountSelfTestingScreeningResults webpage
+  When I select Negative for //*[@id="resultdropdown"]
+  And I click the button //*[@id="btn-nextMask"]
+  pause for 1s
+  #Then the URI should start with AccountSelfTestingScreeningReview

--- a/test/backgrounds/flows/account-self-testing-screening-results-positive.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-results-positive.feature
@@ -1,0 +1,6 @@
+Self Testing Step 3b.
+  On the AccountSelfTestingScreeningResults webpage
+  When I select Positive for //*[@id="resultdropdown"]
+  And I click the button //*[@id="btn-nextMask"]
+  pause for 1s
+  #Then the URI should start with AccountSelfTestingScreeningReview

--- a/test/backgrounds/flows/account-self-testing-screening-review.feature
+++ b/test/backgrounds/flows/account-self-testing-screening-review.feature
@@ -1,0 +1,5 @@
+Self Testing Step 4.
+  On the AccountSelfTestingScreeningReview webpage
+  And I click the button //*[@id="btn-next"]
+  pause for 1s
+#   Then the URI should start with AccountSelfTestingScreeningAnalysis

--- a/test/backgrounds/flows/account-self-testing-worksite.feature
+++ b/test/backgrounds/flows/account-self-testing-worksite.feature
@@ -1,0 +1,5 @@
+Self Testing Step 1.
+  On the AccountSelfTestingWorksite webpage
+  When I input A1A 1A1 for //*[@id="postalcode"]
+  And I click the button //*[@id="btn-nextMask"]
+  Then the URI should start with AccountSelfTestingScreeningKit

--- a/test/backgrounds/flows/account-self-testing.feature
+++ b/test/backgrounds/flows/account-self-testing.feature
@@ -1,0 +1,3 @@
+  On the AccountHome webpage
+  When I click the button AccountMenuSelfTesting
+  Then the URI should start with AccountSelfTestingWorksite

--- a/test/backgrounds/int/service/lang/en.feature
+++ b/test/backgrounds/int/service/lang/en.feature
@@ -10,7 +10,14 @@ Set AccountHome to https://workplace.alpha.canada.ca/en/index/
 Set SignOutMenu to :text("Sign out")
 
 Set AccountProfile to https://workplace.alpha.canada.ca/en/contactdetails/
+Set AccountSelfTestingWorksite to https://workplace.alpha.canada.ca/en/home-screening-worksite/
+Set AccountSelfTestingScreeningKit to https://workplace.alpha.canada.ca/en/home-screening-kit/
+Set AccountSelfTestingScreeningResults to https://workplace.alpha.canada.ca/en/home-screening-results/
+Set AccountSelfTestingScreeningAttestation to https://workplace.alpha.canada.ca/en/home-screening-attestation/
+Set AccountSelfTestingScreeningReview to https://workplace.alpha.canada.ca/en/home-screening-review/
+Set AccountSelfTestingScreeningAnalysis to https://workplace.alpha.canada.ca/en/home-screening-analysis/
 Set AccountVaccineAttestation to https://workplace.alpha.canada.ca/en/va-privacy/
 
 Set AccountMenuProfile to :text('My Profile') >> visible=true
+Set AccountMenuSelfTesting to :text('Self Testing') >> visible=true
 Set AccountMenuVaccineAttestation to .home-btn:near(:text("Vaccine attestation"), 100)

--- a/test/features/account-login/en.feature
+++ b/test/features/account-login/en.feature
@@ -1,4 +1,4 @@
 
-Feature: Account Profile (en)
+Feature: Account Login (en)
 
 Backgrounds: service/lang/en, flows/auth-sign-in

--- a/test/features/account-self-testing-confirmatory-inconclusive/en.feature
+++ b/test/features/account-self-testing-confirmatory-inconclusive/en.feature
@@ -1,0 +1,4 @@
+
+Feature: Account Self Testing Confirmatory Inconclusive (en)
+
+Backgrounds: service/lang/en, flows/auth-sign-in, flows/account-self-testing, flows/account-self-testing-worksite, flows/account-self-testing-screening-kit-confirmatory, flows/account-self-testing-screening-results-inconclusive, flows/account-self-testing-screening-review, flows/account-self-testing-screening-analysis, flows/auth-sign-out

--- a/test/features/account-self-testing-confirmatory-negative/en.feature
+++ b/test/features/account-self-testing-confirmatory-negative/en.feature
@@ -1,0 +1,4 @@
+
+Feature: Account Self Testing Confirmatory Negative (en)
+
+Backgrounds: service/lang/en, flows/auth-sign-in, flows/account-self-testing, flows/account-self-testing-worksite, flows/account-self-testing-screening-kit-confirmatory, flows/account-self-testing-screening-results-negative, flows/account-self-testing-screening-review, flows/account-self-testing-screening-analysis, flows/auth-sign-out

--- a/test/features/account-self-testing-confirmatory-positive/en.feature
+++ b/test/features/account-self-testing-confirmatory-positive/en.feature
@@ -1,0 +1,4 @@
+
+Feature: Account Self Testing Confirmatory Positive (en)
+
+Backgrounds: service/lang/en, flows/auth-sign-in, flows/account-self-testing, flows/account-self-testing-worksite, flows/account-self-testing-screening-kit-confirmatory, flows/account-self-testing-screening-results-positive, flows/account-self-testing-screening-review, flows/account-self-testing-screening-analysis, flows/auth-sign-out

--- a/test/features/account-self-testing-quidel-agree-inconclusive/en.feature
+++ b/test/features/account-self-testing-quidel-agree-inconclusive/en.feature
@@ -1,0 +1,4 @@
+
+Feature: Account Self Testing Quidel Agree Inconclusive (en)
+
+Backgrounds: service/lang/en, flows/auth-sign-in, flows/account-self-testing, flows/account-self-testing-worksite, flows/account-self-testing-screening-kit-quidel, flows/account-self-testing-screening-attestation-agree, flows/account-self-testing-screening-results-inconclusive, flows/account-self-testing-screening-review, flows/account-self-testing-screening-analysis, flows/auth-sign-out

--- a/test/features/account-self-testing-quidel-agree-negative/en.feature
+++ b/test/features/account-self-testing-quidel-agree-negative/en.feature
@@ -1,0 +1,4 @@
+
+Feature: Account Self Testing Quidel Agree Negative (en)
+
+Backgrounds: service/lang/en, flows/auth-sign-in, flows/account-self-testing, flows/account-self-testing-worksite, flows/account-self-testing-screening-kit-quidel, flows/account-self-testing-screening-attestation-agree, flows/account-self-testing-screening-results-negative, flows/account-self-testing-screening-review, flows/account-self-testing-screening-analysis, flows/auth-sign-out

--- a/test/features/account-self-testing-quidel-agree-positive/en.feature
+++ b/test/features/account-self-testing-quidel-agree-positive/en.feature
@@ -1,0 +1,4 @@
+
+Feature: Account Self Testing Quidel Agree Positive (en)
+
+Backgrounds: service/lang/en, flows/auth-sign-in, flows/account-self-testing, flows/account-self-testing-worksite, flows/account-self-testing-screening-kit-quidel, flows/account-self-testing-screening-attestation-agree, flows/account-self-testing-screening-results-positive, flows/account-self-testing-screening-review, flows/account-self-testing-screening-analysis, flows/auth-sign-out

--- a/test/features/account-self-testing-quidel-disagree/en.feature
+++ b/test/features/account-self-testing-quidel-disagree/en.feature
@@ -1,0 +1,4 @@
+
+Feature: Account Self Testing Quidel Disagree (en)
+
+Backgrounds: service/lang/en, flows/auth-sign-in, flows/account-self-testing, flows/account-self-testing-worksite, flows/account-self-testing-screening-kit-quidel, flows/account-self-testing-screening-attestation-disagree, flows/account-self-testing-screening-analysis, flows/auth-sign-out

--- a/test/features/lang/en.feature
+++ b/test/features/lang/en.feature
@@ -1,4 +1,4 @@
 
-Feature: Account Profile (en)
+Feature: Language (en)
 
 Backgrounds: service/lang/en, flows/lang


### PR DESCRIPTION
Adds Account Self Testing flows.

### Note
Some of these tests are brittle due to an inability to pass data from one step to next (e.g. Screening Results page and Screening Analysis rely on an `sid` in the URI query var).
